### PR TITLE
Update minimist dependency and .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+examples
+test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mkdirp",
   "description": "Recursively mkdir, like `mkdir -p`",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "James Halliday <mail@substack.net> (http://substack.net)",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "minimist": "0.0.8"
+    "minimist": ">= 1.1.3"
   },
   "devDependencies": {
     "tap": "1",


### PR DESCRIPTION
The dependency on minimist was out of date.

Resolve #42.

Please `npm publish` in case you accept this PR.
