### PR TITLE
adds coverage reports using coveralls.io and nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+coverage
+nyc_output
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
   - "iojs"
 before_install:
   - npm install -g npm@~1.4.6
+after_success: npm run coveralls

--- a/package.json
+++ b/package.json
@@ -13,14 +13,18 @@
     "url": "https://github.com/substack/node-mkdirp.git"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tap test/*.js",
+    "coverage": "nyc npm test && nyc report",
+    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
     "minimist": "0.0.8"
   },
   "devDependencies": {
-    "tap": "1",
-    "mock-fs": "2 >=2.7.0"
+    "coveralls": "^2.11.2",
+    "mock-fs": "2 >=2.7.0",
+    "nyc": "^2.1.4",
+    "tap": "1"
   },
   "bin": "bin/cmd.js",
   "license": "MIT"

--- a/readme.markdown
+++ b/readme.markdown
@@ -3,6 +3,7 @@
 Like `mkdir -p`, but in node.js!
 
 [![build status](https://secure.travis-ci.org/substack/node-mkdirp.png)](http://travis-ci.org/substack/node-mkdirp)
+[![Coverage Status](https://coveralls.io/repos/substack/node-mkdirp/badge.svg?branch=)](https://coveralls.io/r/substack/node-mkdirp?branch=)
 
 # example
 
@@ -10,7 +11,7 @@ Like `mkdir -p`, but in node.js!
 
 ```js
 var mkdirp = require('mkdirp');
-    
+
 mkdirp('/tmp/foo/bar/baz', function (err) {
     if (err) console.error(err)
     else console.log('pow!')
@@ -69,7 +70,7 @@ usage: mkdirp [DIR1,DIR2..] {OPTIONS}
 
   Create each supplied directory including any necessary parent directories that
   don't yet exist.
-  
+
   If the directory already exists, do nothing.
 
 OPTIONS are:


### PR DESCRIPTION
This pull adds coverage reporting, using coveralls.io and the [nyc](https://www.npmjs.com/package/nyc) instrumenter.

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
* run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  * you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  * on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN `

Here's what the report looks like:

```shell
---------------|-----------|-----------|-----------|-----------|
File           |   % Stmts |% Branches |   % Funcs |   % Lines |
---------------|-----------|-----------|-----------|-----------|
   ./          |     94.83 |     92.86 |     83.33 |     98.11 |
      index.js |     94.83 |     92.86 |     83.33 |     98.11 |
---------------|-----------|-----------|-----------|-----------|
All files      |     94.83 |     92.86 |     83.33 |     98.11 |
---------------|-----------|-----------|-----------|-----------|
```