### PR TITLE
tap 1.2.0 and update npm version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
   - "0.12"
   - "iojs"
 before_install:
-  - npm install -g npm@~1.4.6
+  - npm install -g npm@latest

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "minimist": "0.0.8"
   },
   "devDependencies": {
-    "tap": "1",
-    "mock-fs": "2 >=2.7.0"
+    "mock-fs": "2 >=2.7.0",
+    "tap": "^1.2.0"
   },
   "bin": "bin/cmd.js",
   "license": "MIT"


### PR DESCRIPTION
Bump the version of tap.

After this PR, if you sign up with http://coveralls.io, and then put a `COVERALLS_REPO_TOKEN` environment var in travis, then coverage will happen.