### PR TITLE
Null byte filename causes crash on node 4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,8 @@ function mkdirP (p, opts, f, made) {
         }
         switch (er.code) {
             case 'ENOENT':
+                // If there's a null byte in the filename that's an error we can't recover from
+                if (p.match(/\0/)) { return cb(er); }
                 mkdirP(path.dirname(p), opts, function (er, made) {
                     if (er) cb(er, made);
                     else mkdirP(p, opts, cb, made);
@@ -74,6 +76,8 @@ mkdirP.sync = function sync (p, opts, made) {
     catch (err0) {
         switch (err0.code) {
             case 'ENOENT' :
+                // If there's a null byte in the filename that's an error we can't recover from
+                if (p.match(/\0/)) { return cb(er); }
                 made = sync(path.dirname(p), opts, made);
                 sync(p, opts, made);
                 break;


### PR DESCRIPTION
On node 0.12.2 a null byte filename resulted in an error:

    > var mkdirp = require('mkdirp');
    undefined
    > mkdirp('\0', function(err){console.log(err)});
    undefined
    > [Error: Path must be a string without null bytes.]

On node 4.0.0 this crashes node:

    > var mkdirp = require('mkdirp');
    undefined
    > mkdirp('\0', function(err){console.log(err)});
    undefined
    > 
    <--- Last few GCs --->

       91683 ms: Scavenge 1402.9 (1457.0) -> 1402.9 (1457.0) MB, 8.7 / 0 ms (+ 1.7 ms in 1 steps since last GC) [allocation failure] [incremental marking delaying mark-sweep].
       92621 ms: Mark-sweep 1402.9 (1457.0) -> 1402.9 (1457.0) MB, 937.4 / 0 ms (+ 2.5 ms in 2 steps since start of marking, biggest step 1.7 ms) [last resort gc].
       93670 ms: Mark-sweep 1402.9 (1457.0) -> 1402.8 (1457.0) MB, 1049.3 / 0 ms [last resort gc].
    
    
    <--- JS stacktrace --->
    
    ==== JS stack trace =========================================
    
    Security context: 0x377170037339 <JS Object>
        1: ToString [native runtime.js:~563] [pc=0x1528a515caeb] (this=0x3771700b63f1 <JS Global Object>,i=-1)
        5: _tickCallback(aka _tickDomainCallback) [node.js:~361] [pc=0x1528a516244b] (this=0x3771700b62c9 <a process with map 0x2bd22a1ad61>)
    
    ==== Details ================================================
    
    [1]: ToString [native runtime.js:~563] [pc=0x1528a515caeb] (this=0x3771700b63f1 <JS Glob...
    
    FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - process out of memory
    Aborted