### PR TITLE
tools: update tap + mock-fs. Fix broken test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs"
+  - "4"
+  - "5"
 before_install:
   - npm install -g npm@~1.4.6

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "minimist": "0.0.8"
   },
   "devDependencies": {
-    "tap": "1",
-    "mock-fs": "2 >=2.7.0"
+    "mock-fs": "^3.7.0",
+    "tap": "^5.4.2"
   },
   "bin": "bin/cmd.js",
   "license": "MIT"

--- a/test/perm.js
+++ b/test/perm.js
@@ -28,5 +28,4 @@ test('async root perm', function (t) {
         if (err) t.fail(err);
         t.end();
     });
-    t.end();
 });


### PR DESCRIPTION
The test suite is currently failing on anything higher than v4

Updating mock-fs fixes this. As tap was quite out of date I have
updated that as well.

After updating the dependencies a test began failing due to
`test.end()` being called more than once. This is fixed