### PR TITLE
fix for type error

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,11 +85,11 @@ mkdirP.sync = function sync (p, opts, made) {
                 var stat;
                 try {
                     stat = xfs.statSync(p);
+                    if (!stat.isDirectory()) throw err1;
                 }
                 catch (err1) {
                     throw err0;
                 }
-                if (!stat.isDirectory()) throw err0;
                 break;
         }
     }


### PR DESCRIPTION
* when checking for the existence of the directory in some cases the stat variable did not have a isDirectory method
* e.g. when passing some variable to the sync method where opts is not a legit fs object
* occured when running a test with istanbul + mocha