### PR TITLE
Ignore redundant file from package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+test
+examples
+.travis.yml


### PR DESCRIPTION
test and examples folders will not be required for the package end-user