### PR TITLE
Test suite: Safe tests, and clean up after

### DIFF
--- a/test/chmod.js
+++ b/test/chmod.js
@@ -2,18 +2,13 @@ var mkdirp = require('../').mkdirp;
 var path = require('path');
 var fs = require('fs');
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 var _0744 = parseInt('0744', 8);
 
-var ps = [ '', 'tmp' ];
-
-for (var i = 0; i < 25; i++) {
-    var dir = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    ps.push(dir);
-}
-
-var file = ps.join('/');
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+var file = testUtils.randomDeepFile(tmpDir, 25, 4);
 
 test('chmod-pre', function (t) {
     var mode = _0744
@@ -38,4 +33,9 @@ test('chmod', function (t) {
             t.end();
         });
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/clobber.js
+++ b/test/clobber.js
@@ -2,20 +2,14 @@ var mkdirp = require('../').mkdirp;
 var path = require('path');
 var fs = require('fs');
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0755 = parseInt('0755', 8);
 
-var ps = [ '', 'tmp' ];
-
-for (var i = 0; i < 25; i++) {
-    var dir = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    ps.push(dir);
-}
-
-var file = ps.join('/');
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+var file = testUtils.randomDeepFile(tmpDir, 25, 4);
 
 // a file in the way
-var itw = ps.slice(0, 3).join('/');
-
+var itw = file.split('/').slice(0, 3).join('/');
 
 test('clobber-pre', function (t) {
     console.error("about to write to "+itw)
@@ -35,4 +29,9 @@ test('clobber', function (t) {
         t.equal(err.code, 'ENOTDIR');
         t.end();
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/mkdirp.js
+++ b/test/mkdirp.js
@@ -3,16 +3,16 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
 test('woo', function (t) {
     t.plan(5);
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
     
-    var file = '/tmp/' + [x,y,z].join('/');
+    var file = testUtils.randomDeepFile(tmpDir, 3, 4);
     
     mkdirp(file, _0755, function (err) {
         t.ifError(err);
@@ -25,4 +25,9 @@ test('woo', function (t) {
             })
         })
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/opts_fs.js
+++ b/test/opts_fs.js
@@ -1,19 +1,18 @@
 var mkdirp = require('../');
 var path = require('path');
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var mockfs = require('mock-fs');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
 test('opts.fs', function (t) {
     t.plan(5);
-    
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    
-    var file = '/beep/boop/' + [x,y,z].join('/');
+
     var xfs = mockfs.fs();
+    testUtils.setFS(xfs);
+
+    var file = testUtils.randomDeepFile('/beep/boop/', 3, 4);
     
     mkdirp(file, { fs: xfs, mode: _0755 }, function (err) {
         t.ifError(err);

--- a/test/opts_fs_sync.js
+++ b/test/opts_fs_sync.js
@@ -1,19 +1,18 @@
 var mkdirp = require('../');
 var path = require('path');
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var mockfs = require('mock-fs');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
 test('opts.fs sync', function (t) {
     t.plan(4);
-    
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    
-    var file = '/beep/boop/' + [x,y,z].join('/');
+
     var xfs = mockfs.fs();
+    testUtils.setFS(xfs);
+
+    var file = testUtils.randomDeepFile('/beep/boop/', 3, 4);
     
     mkdirp.sync(file, { fs: xfs, mode: _0755 });
     xfs.exists(file, function (ex) {

--- a/test/perm.js
+++ b/test/perm.js
@@ -3,12 +3,15 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
 test('async perm', function (t) {
     t.plan(5);
-    var file = '/tmp/' + (Math.random() * (1<<30)).toString(16);
+    var file = testUtils.randomDeepFile(tmpDir, 1, 4);
     
     mkdirp(file, _0755, function (err) {
         t.ifError(err);
@@ -24,8 +27,14 @@ test('async perm', function (t) {
 });
 
 test('async root perm', function (t) {
-    mkdirp('/tmp', _0755, function (err) {
+    var file = '/tmp';
+    mkdirp(file, _0755, function (err) {
         if (err) t.fail(err);
         t.end();
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/perm_sync.js
+++ b/test/perm_sync.js
@@ -3,12 +3,15 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
 test('sync perm', function (t) {
     t.plan(4);
-    var file = '/tmp/' + (Math.random() * (1<<30)).toString(16) + '.json';
+    var file = testUtils.randomDeepFile(tmpDir, 1, 4);
     
     mkdirp.sync(file, _0755);
     exists(file, function (ex) {
@@ -33,4 +36,9 @@ test('sync root perm', function (t) {
             t.ok(stat.isDirectory(), 'target not a directory');
         })
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/race.js
+++ b/test/race.js
@@ -3,22 +3,18 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
+// Two mkdirp() requests on the same dir should succeed.
 test('race', function (t) {
     t.plan(10);
-    var ps = [ '', 'tmp' ];
-    
-    for (var i = 0; i < 25; i++) {
-        var dir = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-        ps.push(dir);
-    }
-    var file = ps.join('/');
-    
-    var res = 2;
+
+    var file = testUtils.randomDeepFile(tmpDir, 25, 4);
     mk(file);
-    
     mk(file);
     
     function mk (file, cb) {
@@ -34,4 +30,9 @@ test('race', function (t) {
             })
         });
     }
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/rel.js
+++ b/test/rel.js
@@ -3,19 +3,21 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
-test('rel', function (t) {
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
+test('mkdirp with relative path', function (t) {
     t.plan(5);
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
     
     var cwd = process.cwd();
-    process.chdir('/tmp');
+
+    fs.mkdirSync(tmpDir);
+    process.chdir(tmpDir);
     
-    var file = [x,y,z].join('/');
+    var file = testUtils.randomDeepFile('', 3, 4);
     
     mkdirp(file, _0755, function (err) {
         t.ifError(err);
@@ -29,4 +31,9 @@ test('rel', function (t) {
             })
         })
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/return.js
+++ b/test/return.js
@@ -2,24 +2,38 @@ var mkdirp = require('../');
 var path = require('path');
 var fs = require('fs');
 var test = require('tap').test;
+var testUtils = require('./utils/');
+
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
 
 test('return value', function (t) {
     t.plan(4);
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
 
-    var file = '/tmp/' + [x,y,z].join('/');
+    // mkdirp returns the first dir created. Ensure /tmp exists.
+    try {
+      fs.mkdirSync('/tmp');
+    }
+    catch (err) {
+      if (err.code !== 'EEXIST')
+      {
+        t.fail(err);
+        return t.end();
+      }
+    }
 
-    // should return the first dir created.
-    // By this point, it would be profoundly surprising if /tmp didn't
-    // already exist, since every other test makes things in there.
+    var file = testUtils.randomDeepFile(tmpDir, 3, 4);
+
     mkdirp(file, function (err, made) {
         t.ifError(err);
-        t.equal(made, '/tmp/' + x);
+        t.equal(made, file.split('/').slice(0, 3).join('/'));
         mkdirp(file, function (err, made) {
           t.ifError(err);
           t.equal(made, null);
         });
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/return_sync.js
+++ b/test/return_sync.js
@@ -2,23 +2,37 @@ var mkdirp = require('../');
 var path = require('path');
 var fs = require('fs');
 var test = require('tap').test;
+var testUtils = require('./utils/');
+
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
 
 test('return value', function (t) {
     t.plan(2);
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
 
-    var file = '/tmp/' + [x,y,z].join('/');
+    // mkdirp.sync returns the first dir created. Ensure /tmp exists.
+    try {
+      fs.mkdirSync('/tmp');
+    }
+    catch (err) {
+      if (err.code !== 'EEXIST')
+      {
+        t.fail(err);
+        return t.end();
+      }
+    }
 
-    // should return the first dir created.
-    // By this point, it would be profoundly surprising if /tmp didn't
-    // already exist, since every other test makes things in there.
+    var file = testUtils.randomDeepFile(tmpDir, 3, 4);
+
     // Note that this will throw on failure, which will fail the test.
     var made = mkdirp.sync(file);
-    t.equal(made, '/tmp/' + x);
+    t.equal(made, file.split('/').slice(0, 3).join('/'));
 
     // making the same file again should have no effect.
     made = mkdirp.sync(file);
     t.equal(made, null);
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/sync.js
+++ b/test/sync.js
@@ -3,16 +3,16 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
 test('sync', function (t) {
     t.plan(4);
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
 
-    var file = '/tmp/' + [x,y,z].join('/');
+    var file = testUtils.randomDeepFile(tmpDir, 3, 4);
 
     try {
         mkdirp.sync(file, _0755);
@@ -29,4 +29,9 @@ test('sync', function (t) {
             t.ok(stat.isDirectory(), 'target not a directory');
         });
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/umask.js
+++ b/test/umask.js
@@ -3,16 +3,16 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
 test('implicit mode from umask', function (t) {
     t.plan(5);
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    
-    var file = '/tmp/' + [x,y,z].join('/');
+
+    var file = testUtils.randomDeepFile(tmpDir, 3, 4);
     
     mkdirp(file, function (err) {
         t.ifError(err);
@@ -25,4 +25,9 @@ test('implicit mode from umask', function (t) {
             });
         })
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/umask_sync.js
+++ b/test/umask_sync.js
@@ -3,16 +3,16 @@ var path = require('path');
 var fs = require('fs');
 var exists = fs.exists || path.exists;
 var test = require('tap').test;
+var testUtils = require('./utils/');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
 
+var tmpDir = testUtils.mktemp('/tmp/node-mkdirp_test_');
+
 test('umask sync modes', function (t) {
     t.plan(4);
-    var x = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var y = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
-    var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
 
-    var file = '/tmp/' + [x,y,z].join('/');
+    var file = testUtils.randomDeepFile(tmpDir, 3, 4);
 
     try {
         mkdirp.sync(file);
@@ -29,4 +29,9 @@ test('umask sync modes', function (t) {
             t.ok(stat.isDirectory(), 'target not a directory');
         });
     });
+});
+
+test('cleanup', function(t) {
+  testUtils.cleanup(tmpDir);
+  t.end();
 });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,0 +1,100 @@
+var fs = require('fs');
+
+var xfs = fs;
+
+/* Change the underlying FS implementation we rely on.
+ * newFS must support the Node.js fs APIs.
+ */
+function setFS (newFS) {
+  xfs = newFS;
+}
+
+/* Returns true if f exists, else false. */
+function exists (f) {
+  try {
+    xfs.statSync(f);
+  }
+  catch (err) {
+    return false;
+  }
+
+  return true;
+}
+
+/* Returns the name of a file that does not currently exist, beginning with the prefix 'template' and in the same dir.
+ * Performs a synchronous search of 16^6 possible file names.
+ * See man 3 mktemp.
+ */
+function mktemp (template) {
+  var name;
+  while (1) {
+    name = template + Math.floor(Math.random() * Math.pow(16, 6)).toString(16);
+    try {
+      var stat = xfs.statSync(name);
+    }
+    catch (err) {
+      if (err.code === 'ENOENT')
+        return name;
+    }
+  }
+}
+
+/* Returns a filename in a child dir underneath root.
+ *   root:  where to start (does not need to end in '/')
+ *          if '', we make a relative path 'x/y/z/...'
+ *          otherwise, path is 'root/x/y/z/...'
+ *   depth: how many levels
+ *   width: how wide the file name at each level should be
+ */
+function randomDeepFile (root, depth, width) {
+  var ps = [];
+  for (var i = 0; i < depth; i++) {
+    var dir = Math.floor(Math.random() * Math.pow(16, width)).toString(16);
+    ps.push(dir);
+  }
+
+  var subTree = ps.join('/');
+  var f;
+  if (root)
+    f = root + '/' + subTree;
+  else
+    f = subTree;
+  return f;
+}
+
+/* 'rm -rf f_or_d'.
+ * Assumes directories contain only normal files and directories.
+ * Use with caution.
+ */
+function cleanup (f_or_d) {
+  if (!exists(f_or_d))
+    return;
+
+  var stat = xfs.statSync(f_or_d);
+  if (stat.isFile())
+  {
+    xfs.unlinkSync(f_or_d);
+    return;
+  }
+  else if (stat.isDirectory())
+  {
+    var entries = xfs.readdirSync(f_or_d);
+    for (var i = 0; i < entries.length; i++)
+    {
+      var entry = entries[i];
+      var abs = f_or_d + '/' + entry;
+      cleanup(abs);
+    }
+    xfs.rmdirSync(f_or_d);
+  }
+
+  return;
+}
+
+module.exports = {
+  setFS: setFS,
+  exists: exists,
+  mktemp: mktemp,
+  randomDeepFile: randomDeepFile,
+  cleanup: cleanup,
+};


### PR DESCRIPTION
1. Introduce a 'utils' module for testing for common functionality. DRY.

2. Ensure that we use a 'fresh' dir for every test.
   The prior approach relied on randomness, but if you ran the test
   suite enough you would saturate the directory space and hit spurious
   failures (only 16^4 choices per test dir level).

3. Add a 'cleanup' test in each test case to delete the tmp test dirs.

This addresses #118.