### PR TITLE
avoid returning outside function

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -10,7 +10,7 @@ var argv = minimist(process.argv.slice(2), {
 });
 if (argv.help) {
     fs.createReadStream(__dirname + '/usage.txt').pipe(process.stdout);
-    process.exit(1);
+    process.exit(0);
 }
 
 var paths = argv._.slice();

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -10,7 +10,7 @@ var argv = minimist(process.argv.slice(2), {
 });
 if (argv.help) {
     fs.createReadStream(__dirname + '/usage.txt').pipe(process.stdout);
-    return;
+    process.exit(1);
 }
 
 var paths = argv._.slice();


### PR DESCRIPTION
Babel reports a SyntaxError when encountering this.