### PR TITLE
Update tests to support Node.js 6.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ node_js:
   - "iojs"
   - "4"
   - "5"
+  - "6"
 before_install:
   - npm install -g npm@~1.4.6

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "minimist": "0.0.8"
   },
   "devDependencies": {
-    "mock-fs": "^3.7.0",
+    "mock-fs": "^3.10.0",
     "tap": "^5.4.2"
   },
   "bin": "bin/cmd.js",

--- a/test/opts_fs.js
+++ b/test/opts_fs.js
@@ -1,6 +1,7 @@
 var mkdirp = require('../');
 var path = require('path');
 var test = require('tap').test;
+var fs = require('fs');
 var mockfs = require('mock-fs');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
@@ -13,16 +14,18 @@ test('opts.fs', function (t) {
     var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
     
     var file = '/beep/boop/' + [x,y,z].join('/');
-    var xfs = mockfs.fs();
+    mockfs();
     
-    mkdirp(file, { fs: xfs, mode: _0755 }, function (err) {
+    mkdirp(file, { mode: _0755 }, function (err) {
         t.ifError(err);
-        xfs.exists(file, function (ex) {
+        fs.exists(file, function (ex) {
             t.ok(ex, 'created file');
-            xfs.stat(file, function (err, stat) {
+            fs.stat(file, function (err, stat) {
                 t.ifError(err);
                 t.equal(stat.mode & _0777, _0755);
                 t.ok(stat.isDirectory(), 'target not a directory');
+
+                mockfs.restore();
             });
         });
     });

--- a/test/opts_fs_sync.js
+++ b/test/opts_fs_sync.js
@@ -1,6 +1,7 @@
 var mkdirp = require('../');
 var path = require('path');
 var test = require('tap').test;
+var fs = require('fs');
 var mockfs = require('mock-fs');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
@@ -13,15 +14,17 @@ test('opts.fs sync', function (t) {
     var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
     
     var file = '/beep/boop/' + [x,y,z].join('/');
-    var xfs = mockfs.fs();
+    mockfs();
     
-    mkdirp.sync(file, { fs: xfs, mode: _0755 });
-    xfs.exists(file, function (ex) {
+    mkdirp.sync(file, { mode: _0755 });
+    fs.exists(file, function (ex) {
         t.ok(ex, 'created file');
-        xfs.stat(file, function (err, stat) {
+        fs.stat(file, function (err, stat) {
             t.ifError(err);
             t.equal(stat.mode & _0777, _0755);
             t.ok(stat.isDirectory(), 'target not a directory');
+
+            mockfs.restore();
         });
     });
 });


### PR DESCRIPTION
Tests not guaranteed to run properly on latest Node.js LTS (v6.10.2)
due to dependency on mock-fs@3.7.0. Update to mock-fs@3.10.0 or higher
to enable proper function with Node.js LTS v6.10.2