### PR TITLE
fix: illegal path cause recursive

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,14 @@ function mkdirP (p, opts, f, made) {
         }
         switch (er.code) {
             case 'ENOENT':
-                mkdirP(path.dirname(p), opts, function (er, made) {
-                    if (er) cb(er, made);
-                    else mkdirP(p, opts, cb, made);
-                });
+                if (err.message.indexOf('null bytes') !== -1) { // may throw "Path must be a string without null bytes"
+                    cb(er, made);
+                } else {
+                    mkdirP(path.dirname(p), opts, function (er, made) {
+                        if (er) cb(er, made);
+                        else mkdirP(p, opts, cb, made);
+                    });
+                }
                 break;
 
             // In the case of any other error, just see if there's a dir

--- a/test/illegal_path.js
+++ b/test/illegal_path.js
@@ -1,0 +1,16 @@
+var mkdirp = require('../');
+var path = require('path');
+var fs = require('fs');
+var exists = fs.exists || path.exists;
+var test = require('tap').test;
+var _0777 = parseInt('0777', 8);
+var _0755 = parseInt('0755', 8);
+
+test('illegal_path', function (t) {
+    // internal fs.mkdir will throw err if path is illegal
+    var file = '/tmp/\x00\x00\x00';
+    
+    mkdirp(file, _0755, function (err) {
+        t.true(err.code === 'ENOENT');
+    });
+});


### PR DESCRIPTION
```
var mkdirp = require('mkdirp')
mkdirp('\x00\x00\x00')
```

will cause endless recursive