### PR TITLE
9.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "iojs"
   - "4"
-  - "5"
-before_install:
-  - npm install -g npm@~1.4.6
+  - "6"
+  - "8"
+  - "9"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "minimist": "0.0.8"
   },
   "devDependencies": {
-    "mock-fs": "^3.7.0",
-    "tap": "^5.4.2"
+    "mock-fs": "^4.4.2",
+    "tap": "^11.0.0"
   },
   "bin": "bin/cmd.js",
   "license": "MIT"

--- a/test/opts_fs.js
+++ b/test/opts_fs.js
@@ -1,6 +1,7 @@
 var mkdirp = require('../');
 var path = require('path');
 var test = require('tap').test;
+var fs = require('fs');
 var mockfs = require('mock-fs');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
@@ -13,16 +14,17 @@ test('opts.fs', function (t) {
     var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
     
     var file = '/beep/boop/' + [x,y,z].join('/');
-    var xfs = mockfs.fs();
+    mockfs();
     
-    mkdirp(file, { fs: xfs, mode: _0755 }, function (err) {
+    mkdirp(file, { mode: _0755 }, function (err) {
         t.ifError(err);
-        xfs.exists(file, function (ex) {
+        fs.exists(file, function (ex) {
             t.ok(ex, 'created file');
-            xfs.stat(file, function (err, stat) {
+            fs.stat(file, function (err, stat) {
                 t.ifError(err);
                 t.equal(stat.mode & _0777, _0755);
                 t.ok(stat.isDirectory(), 'target not a directory');
+                mockfs.restore();
             });
         });
     });

--- a/test/opts_fs_sync.js
+++ b/test/opts_fs_sync.js
@@ -1,6 +1,7 @@
 var mkdirp = require('../');
 var path = require('path');
 var test = require('tap').test;
+var fs = require('fs');
 var mockfs = require('mock-fs');
 var _0777 = parseInt('0777', 8);
 var _0755 = parseInt('0755', 8);
@@ -13,15 +14,16 @@ test('opts.fs sync', function (t) {
     var z = Math.floor(Math.random() * Math.pow(16,4)).toString(16);
     
     var file = '/beep/boop/' + [x,y,z].join('/');
-    var xfs = mockfs.fs();
+    mockfs();
     
-    mkdirp.sync(file, { fs: xfs, mode: _0755 });
-    xfs.exists(file, function (ex) {
+    mkdirp.sync(file, { mode: _0755 });
+    fs.exists(file, function (ex) {
         t.ok(ex, 'created file');
-        xfs.stat(file, function (err, stat) {
+        fs.stat(file, function (err, stat) {
             t.ifError(err);
             t.equal(stat.mode & _0777, _0755);
             t.ok(stat.isDirectory(), 'target not a directory');
+            mockfs.restore();
         });
     });
 });


### PR DESCRIPTION
This updates the dependencies for tap and mock-fs and modifies tests that were broken by the update.

The second commit updates the travis.yml file to test against a more modern matrix