### PR TITLE
Fix non-strict syntax by removing global require

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -8,26 +8,26 @@ var argv = minimist(process.argv.slice(2), {
     alias: { m: 'mode', h: 'help' },
     string: [ 'mode' ]
 });
+
 if (argv.help) {
-    fs.createReadStream(__dirname + '/usage.txt').pipe(process.stdout);
-    return;
-}
+  fs.createReadStream(__dirname + '/usage.txt').pipe(process.stdout);
+} else {
+  var paths = argv._.slice();
+  var mode = argv.mode ? parseInt(argv.mode, 8) : undefined;
 
-var paths = argv._.slice();
-var mode = argv.mode ? parseInt(argv.mode, 8) : undefined;
-
-(function next () {
+  (function next () {
     if (paths.length === 0) return;
     var p = paths.shift();
-    
+
     if (mode === undefined) mkdirp(p, cb)
     else mkdirp(p, mode, cb)
-    
+
     function cb (err) {
-        if (err) {
-            console.error(err.message);
-            process.exit(1);
-        }
-        else next();
+      if (err) {
+        console.error(err.message);
+        process.exit(1);
+      }
+      else next();
     }
-})();
+  })();
+}


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: ssbc/ssb-server#683